### PR TITLE
Fix/special level and gauge

### DIFF
--- a/Assets/CharacterLocator.cs
+++ b/Assets/CharacterLocator.cs
@@ -25,8 +25,8 @@ public class CharacterLocator : MonoBehaviour
     public Subject<int> _getDamageSubject = new Subject<int>();
 
     //スペシャル関連
-    public ReactiveProperty<int> _characterSpecialLevel { get; set; } = new ReactiveProperty<int>(0); //スペシャルゲージ。最大1。0.1ずつ上昇。
-    public Subject<int> _getSpecialLevelSubject = new Subject<int>();
+    //スペシャルゲージ。最大6。参照: CharacterSpecialLevel.cs
+    public CharacterSpecialLevel _characterSpecialLevel { get; set; } = new CharacterSpecialLevel(0);
     public Subject<Unit> _playSpecialSubject = new Subject<Unit>();
     private float _specialTime = 2f; //2秒間スペシャルで弾を消す
     private bool _isSpecialActive = false;
@@ -75,7 +75,9 @@ public class CharacterLocator : MonoBehaviour
             {
                 Debug.Log($"キャラのHPが変わったよ！現在HP: {hp}");
 
-                _getSpecialLevelSubject.OnNext(_uICharacterGauge._getSpecialPointValue);
+                // キャラのHPが変わったらスペシャルレベルを上げる
+                // ホンマに？
+                _characterSpecialLevel.Increment();
 
                 if (hp <= 0)
                 {
@@ -92,18 +94,6 @@ public class CharacterLocator : MonoBehaviour
                 {
                     GetDamagePoint(damage);
                    
-                }
-            })
-            .AddTo(this);
-
-
-        //スペシャルレベル監視
-        _getSpecialLevelSubject
-            .Subscribe(specialPoint =>
-            {
-                if (_characterSpecialLevel.Value >= 0 && _characterSpecialLevel.Value < 240)
-                {
-                    GetSpecialPoint(specialPoint);
                 }
             })
             .AddTo(this);
@@ -223,10 +213,6 @@ public class CharacterLocator : MonoBehaviour
         this.gameObject.layer = 6;
         await UniTask.Delay(TimeSpan.FromSeconds(_mutekiTime));
         this.gameObject.layer = 3;
-    }
-    private void GetSpecialPoint(int specialPoint)
-    {
-        _characterSpecialLevel.Value += specialPoint;
     }
 
     public async UniTaskVoid CharacterSpecialSet()

--- a/Assets/CharacterSpecialLevel.cs
+++ b/Assets/CharacterSpecialLevel.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using System;
+
+class CharacterSpecialLevel : ReactiveProperty<int>
+{
+    public const int MAX_SPECIAL_LEVEL = 6;
+
+    /// <summary>
+    /// スペシャルレベルをリセットする
+    /// </summary>
+    public void Reset()
+    {
+        this.Value = 0;
+    }
+
+    /// <summary>
+    /// スペシャルレベルの値を設定する
+    /// </summary>
+    /// <param name="Value">スペシャルレベル</param>
+    public void Set(int Value)
+    {
+        this.Value = math_between(0, MAX_SPECIAL_LEVEL, Value);
+    }
+
+    /// <summary>
+    /// スペシャルレベルを一段階増やす。最大値以上にはならない
+    /// </summary>
+    public void Increment()
+    {
+        if (this.Value < MAX_SPECIAL_LEVEL)
+        {
+            this.Value++;
+        }
+    }
+
+    /// <summary>
+    /// スペシャルレベルが最大である
+    /// </summary>
+    /// <returns>最大値であればtrue</returns>
+    public bool IsMaxLevel()
+    {
+        return this.Value == MAX_SPECIAL_LEVEL;
+    }
+
+    private int math_between(int min, int max, int value)
+    {
+        return Math.Max(min, Math.Min(max, value));
+    }
+}

--- a/Assets/UICharacterGauge.cs
+++ b/Assets/UICharacterGauge.cs
@@ -15,7 +15,11 @@ public class UICharacterGauge : MonoBehaviour
     private Vector3 _initSpecialGaugeArrowRotate;
     // Start is called before the first frame update
 
-    public int _getSpecialPointValue { get; set; } = 40; //Specialゲージが増える値
+    /// <summary>スペシャルUI矢印の最小回転角度、初期値</summary>
+    private const int UI_SPECIAL_ROTATE_MIN_DEGREE = -120;
+
+    /// <summary>スペシャルUI矢印の最大回転角度</summary>
+    private const int UI_SPECIAL_ROTATE_MAX_DEGREE = 120;;
 
     private void Awake()
     {
@@ -26,13 +30,18 @@ public class UICharacterGauge : MonoBehaviour
             .DistinctUntilChanged()//同じ値なら無視
             .Subscribe(specialLevel => //値が引数で自動で入る
             {
-                GaugeValueSet(specialLevel);
+                SetUISpecialGauge(specialLevel);
             });
     }
 
-    public void GaugeValueSet(int specialLevel)
+    public void SetUISpecialGauge(int specialLevel)
     {
-        _specialGaugeArrow.DORotate(new Vector3(0, 0, 120 - specialLevel), 0.5f, RotateMode.FastBeyond360).SetEase(Ease.OutExpo);
+        int gap = UI_SPECIAL_ROTATE_MAX_DEGREE - UI_SPECIAL_ROTATE_MIN_DEGREE;
+        int maxLevel = CharacterSpecialLevel.MAX_SPECIAL_LEVEL;
+        int rotate = 1.0 * gap * specialLevel / maxLevel
+        int targetRotate = UI_SPECIAL_ROTATE_MIN_DEGREE + rotate;
+        
+        _specialGaugeArrow.DORotate(new Vector3(0, 0, -targetRotate), 0.5f, RotateMode.FastBeyond360).SetEase(Ease.OutExpo);
         Debug.Log(specialLevel);
     }
 

--- a/Assets/UICharacterGauge.cs
+++ b/Assets/UICharacterGauge.cs
@@ -16,6 +16,7 @@ public class UICharacterGauge : MonoBehaviour
     // Start is called before the first frame update
 
     public int _getSpecialPointValue { get; set; } = 40; //Specialゲージが増える値
+
     private void Awake()
     {
         _initSpecialGaugeArrowRotate = _specialGaugeArrow.localRotation.eulerAngles;
@@ -25,26 +26,14 @@ public class UICharacterGauge : MonoBehaviour
             .DistinctUntilChanged()//同じ値なら無視
             .Subscribe(specialLevel => //値が引数で自動で入る
             {
-                // GaugeValueSet(specialLevel);
-                GaugeValueSet2(specialLevel);
+                GaugeValueSet(specialLevel);
             });
     }
-    public void GaugeValueSet(float specialLevel)
-    {
-        if(GaugeImage.fillAmount <= 1)
-        {
-            GaugeImage.fillAmount = specialLevel;
-        }
-        
-    }
 
-    public void GaugeValueSet2(int specialLevel)
+    public void GaugeValueSet(int specialLevel)
     {
-        //_specialGaugeArrow.localRotation = Quaternion.Euler(_initSpecialGaugeArrowRotate);
-
-        _specialGaugeArrow.DORotate(new Vector3(0, 0, 120 - specialLevel), 0.5f,RotateMode.FastBeyond360).SetEase(Ease.OutExpo);
+        _specialGaugeArrow.DORotate(new Vector3(0, 0, 120 - specialLevel), 0.5f, RotateMode.FastBeyond360).SetEase(Ease.OutExpo);
         Debug.Log(specialLevel);
-
     }
 
 }


### PR DESCRIPTION
動作確認してません！

スペシャルレベル、スペシャルゲージ周辺の処理を修正しました
CharacterSpecialLevelは値がUIに依存しているのでそれを解決します
SpecialLevelは0～6の値を取り、SpecialGaugeRotateはゲージの回転角は-120～120の値を取ります

あと_characterSpecialLevelがReactivePropertyなのだから、_getSpecialLevelSubjectは不要として削除しました
旧処理の
HP変化→OnNext(回転角)で発火→スペシャルレベル更新
の流れは不要なのではないでしょうか？

しらんけど
